### PR TITLE
CSHARP-3292: Enable Additional 2.1 tests on Linux

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1207,6 +1207,7 @@ buildvariants:
   tasks:
      - name: test-netstandard15
      - name: test-netstandard20
+     - name: test-netstandard21
 
 - matrix_name: "tests-zlib-compression-posix"
   matrix_spec: { compressor : "zlib", auth: "noauth", ssl: "nossl", version: ["3.6", "4.0", "4.2", "4.4", "latest"], topology: "standalone", os: "ubuntu-1804" }
@@ -1215,6 +1216,7 @@ buildvariants:
   tasks:
      - name: test-netstandard15
      - name: test-netstandard20
+     - name: test-netstandard21
 
 - matrix_name: "ocsp-tests"
   matrix_spec: { version: ["4.4", "latest"], auth: "noauth", ssl: "ssl", topology: "standalone", os: "windows-64" } # matrix_spec: { version: ["latest"], os-ssl-32: ["ubuntu1604-64-go-1-12"] }


### PR DESCRIPTION
https://spruce.mongodb.com/version/5ff31c2661837d536bd91543/tasks